### PR TITLE
Add BeamsView graphics testing

### DIFF
--- a/Sources/RhythmView/Beam.swift
+++ b/Sources/RhythmView/Beam.swift
@@ -15,15 +15,11 @@ public struct Beam {
     public let path: Path
     
     public init(start: Point, end: Point, width: Double) {
-        
-        let vertices = [
+        self.path = Path(vertices: [
             start.translatedBy(y: 0.5 * width),
             end.translatedBy(y: 0.5 * width),
             end.translatedBy(y: -0.5 * width),
             start.translatedBy(y: -0.5 * width)
-        ]
-        
-        let polygon = Polygon(vertices: vertices)
-        self.path = Path(polygon)
+        ])
     }
 }

--- a/Sources/RhythmView/BeamsView.swift
+++ b/Sources/RhythmView/BeamsView.swift
@@ -22,12 +22,12 @@ public struct BeamsView: Renderable {
         let color: Color
 
         public init(
-            orientation: Orientation,
-            slope: Double,
-            width: Double,
-            beamletLength: Double,
-            displacement: Double,
-            color: Color
+            orientation: Orientation = .stemsDown,
+            slope: Double = 0,
+            width: Double = 10,
+            beamletLength: Double = 16,
+            displacement: Double = 13,
+            color: Color = .black
         )
         {
             self.orientation = orientation
@@ -55,7 +55,7 @@ public struct BeamsView: Renderable {
         self.color = color
     }
 
-    public init(beaming: Beaming, positions: [Double], configuration: Configuration) {
+    public init(beaming: Beaming, positions: [Double], configuration: Configuration = .init()) {
         let builder = Builder(configuration: configuration)
         builder.prepare(beaming, at: positions)
         self = builder.build()

--- a/Tests/RhythmViewTests/BeamsViewTests.swift
+++ b/Tests/RhythmViewTests/BeamsViewTests.swift
@@ -127,39 +127,16 @@ class BeamsViewTests: XCTestCase {
         )
         render(beamsView.rendered, fileName: #function, testCaseName: "\(type(of: self))")
     }
-}
 
-//class BeamsViewTests: GraphicsTestCase {
-//
-//    func testBeamsView() {
-//
-//        let durationTree = 4/>8 * [1,3,4,2,2,1]
-//        let contexts = durationTree.leaves.map { _ in MetricalContext<Int>.instance(.event(0)) }
-//
-//        let rhythm = Rhythm(durationTree, contexts)
-//        let spelling = RhythmSpelling(rhythm)
-//        let spelledRhythm = SpelledRhythm(rhythm: rhythm, spelling: spelling)
-//
-//        let beatWidth: Double = 480
-//        let positions = spelledRhythm.map { offset,_,_ in beatWidth * offset }
-//
-//        let configuration = BeamsView.Configuration(
-//            orientation: .stemsDown,
-//            slope: 0,
-//            width: 4,
-//            beamletLength: 6,
-//            displacement: 6,
-//            color: .black
-//        )
-//
-//        let beamsView = BeamsView(
-//            rhythmSpelling: spelledRhythm.spelling,
-//            positions: positions,
-//            configuration: configuration
-//        )
-//
-//        let layer = CALayer(beamsView.rendered)
-//        layer.showTestBorder()
-//        render(layer, name: "beams_view")
-//    }
-//}
+    func testBeamsWithRhythm() {
+        let rhythm = Rhythm<()>(1/>4, [(4,event(())),(2,event(())),(1,event(())),(2,event(()))])
+        let beaming = DefaultBeamer.beaming(for: rhythm)
+        let configuration = BeamsView.Configuration(slope: -0.125)
+        let beamsView = BeamsView(
+            beaming: beaming,
+            positions: [0,200,300,350],
+            configuration: configuration
+        )
+        render(beamsView.rendered, fileName: #function, testCaseName: "\(type(of: self))")
+    }
+}

--- a/Tests/RhythmViewTests/BeamsViewTests.swift
+++ b/Tests/RhythmViewTests/BeamsViewTests.swift
@@ -66,6 +66,40 @@ class BeamsViewTests: XCTestCase {
         let beamsView = BeamsView(beams: [a,b], color: .black)
         render(beamsView.rendered, fileName: #function, testCaseName: "\(type(of: self))")
     }
+
+    func testBeamStraightWithBeaming() {
+        let beaming = Beaming([.init(start: 1), .init(stop: 1)])
+        let beamsView = BeamsView(beaming: beaming, positions: [0, 100])
+        render(beamsView.rendered, fileName: #function, testCaseName: "\(type(of: self))")
+    }
+
+    func testBeamsStraightWithBeaming() {
+        let beaming = Beaming([.init(start: 2), .init(stop: 2)])
+        let beamsView = BeamsView(beaming: beaming, positions: [0, 100])
+        render(beamsView.rendered, fileName: #function, testCaseName: "\(type(of: self))")
+    }
+
+    func testBeamsAngledDownWithBeaming() {
+        let beaming = Beaming([.init(start: 2), .init(stop: 2)])
+        let configuration = BeamsView.Configuration(slope: 0.25)
+        let beamsView = BeamsView(
+            beaming: beaming,
+            positions: [0, 100],
+            configuration: configuration
+        )
+        render(beamsView.rendered, fileName: #function, testCaseName: "\(type(of: self))")
+    }
+
+    func testBeamsAngledUpWithBeaming() {
+        let beaming = Beaming([.init(start: 2), .init(stop: 2)])
+        let configuration = BeamsView.Configuration(slope: -0.25)
+        let beamsView = BeamsView(
+            beaming: beaming,
+            positions: [0, 100],
+            configuration: configuration
+        )
+        render(beamsView.rendered, fileName: #function, testCaseName: "\(type(of: self))")
+    }
 }
 
 //class BeamsViewTests: GraphicsTestCase {

--- a/Tests/RhythmViewTests/BeamsViewTests.swift
+++ b/Tests/RhythmViewTests/BeamsViewTests.swift
@@ -17,6 +17,57 @@ import QuartzAdapter
 import GraphicsTesting
 
 #warning("Reinstate BeamsViewTests")
+
+class BeamsViewTests: XCTestCase {
+
+    override func setUp() {
+        createArtifactsDirectory(for: "\(type(of: self))")
+    }
+
+    override func tearDown() {
+        openArtifactsDirectory()
+    }
+
+    func testBeamStraight() {
+        let beam = Beam(start: Point(x: 20, y: 20), end: Point(x: 100, y: 20), width: 10)
+        let beamsView = BeamsView(beams: [beam], color: .black)
+        render(beamsView.rendered, fileName: #function, testCaseName: "\(type(of: self))")
+    }
+
+    func testBeamAngledDown() {
+        let beam = Beam(start: Point(x: 20, y: 20), end: Point(x: 100, y: 30), width: 10)
+        let beamsView = BeamsView(beams: [beam], color: .black)
+        render(beamsView.rendered, fileName: #function, testCaseName: "\(type(of: self))")
+    }
+
+    func testBeamAngledUp() {
+        let beam = Beam(start: Point(x: 20, y: 20), end: Point(x: 100, y: 10), width: 10)
+        let beamsView = BeamsView(beams: [beam], color: .black)
+        render(beamsView.rendered, fileName: #function, testCaseName: "\(type(of: self))")
+    }
+
+    func testBeamsStraight() {
+        let a = Beam(start: Point(x: 20, y: 20), end: Point(x: 100, y: 20), width: 10)
+        let b = Beam(start: Point(x: 20, y: 33), end: Point(x: 100, y: 33), width: 10)
+        let beamsView = BeamsView(beams: [a,b], color: .black)
+        render(beamsView.rendered, fileName: #function, testCaseName: "\(type(of: self))")
+    }
+
+    func testBeamsAngledDown() {
+        let a = Beam(start: Point(x: 20, y: 20), end: Point(x: 100, y: 30), width: 10)
+        let b = Beam(start: Point(x: 20, y: 33), end: Point(x: 100, y: 43), width: 10)
+        let beamsView = BeamsView(beams: [a,b], color: .black)
+        render(beamsView.rendered, fileName: #function, testCaseName: "\(type(of: self))")
+    }
+
+    func testBeamsAngledUp() {
+        let a = Beam(start: Point(x: 20, y: 20), end: Point(x: 100, y: 10), width: 10)
+        let b = Beam(start: Point(x: 20, y: 33), end: Point(x: 100, y: 23), width: 10)
+        let beamsView = BeamsView(beams: [a,b], color: .black)
+        render(beamsView.rendered, fileName: #function, testCaseName: "\(type(of: self))")
+    }
+}
+
 //class BeamsViewTests: GraphicsTestCase {
 //
 //    func testBeamsView() {

--- a/Tests/RhythmViewTests/BeamsViewTests.swift
+++ b/Tests/RhythmViewTests/BeamsViewTests.swift
@@ -100,6 +100,33 @@ class BeamsViewTests: XCTestCase {
         )
         render(beamsView.rendered, fileName: #function, testCaseName: "\(type(of: self))")
     }
+
+    func testBeamsAndBeamletsWithBeaming() {
+        let beaming = Beaming([.init(start: 2, beamlets: 2), .init(stop: 2)])
+        let configuration = BeamsView.Configuration(slope: 0.125)
+        let beamsView = BeamsView(
+            beaming: beaming,
+            positions: [0, 100],
+            configuration: configuration
+        )
+        render(beamsView.rendered, fileName: #function, testCaseName: "\(type(of: self))")
+    }
+
+    func testBeamsAndBeamletsWithBeaming2() {
+        let beaming = Beaming([
+            .init(start: 2, beamlets: 2),
+            .init(maintain: 1, stop: 1),
+            .init(maintain: 1, start: 2, beamlets: 3),
+            .init(stop: 3)
+        ])
+        let configuration = BeamsView.Configuration(slope: -0.125)
+        let beamsView = BeamsView(
+            beaming: beaming,
+            positions: [0,50,100,150],
+            configuration: configuration
+        )
+        render(beamsView.rendered, fileName: #function, testCaseName: "\(type(of: self))")
+    }
 }
 
 //class BeamsViewTests: GraphicsTestCase {

--- a/Tests/RhythmViewTests/BeamsViewTests.swift
+++ b/Tests/RhythmViewTests/BeamsViewTests.swift
@@ -129,7 +129,7 @@ class BeamsViewTests: XCTestCase {
     }
 
     func testBeamsWithRhythm() {
-        let rhythm = Rhythm<()>(1/>4, [(4,event(())),(2,event(())),(1,event(())),(2,event(()))])
+        let rhythm = Rhythm(1/>4, [(4,event(())),(2,event(())),(1,event(())),(2,event(()))])
         let beaming = DefaultBeamer.beaming(for: rhythm)
         let configuration = BeamsView.Configuration(slope: -0.125)
         let beamsView = BeamsView(


### PR DESCRIPTION
This PR adds graphical testing for the `BeamsView` structure.

Some example outputs are:

[testBeamAngledDown().pdf](https://github.com/dn-m/NotationView/files/2297603/testBeamAngledDown.pdf)
[testBeamAngledUp().pdf](https://github.com/dn-m/NotationView/files/2297604/testBeamAngledUp.pdf)
[testBeamsAndBeamletsWithBeaming2().pdf](https://github.com/dn-m/NotationView/files/2297605/testBeamsAndBeamletsWithBeaming2.pdf)
[testBeamsStraight().pdf](https://github.com/dn-m/NotationView/files/2297606/testBeamsStraight.pdf)
[testBeamsWithRhythm().pdf](https://github.com/dn-m/NotationView/files/2297607/testBeamsWithRhythm.pdf)
